### PR TITLE
Fix typo in field name: "Anniversay" -> "Anniversary".

### DIFF
--- a/vcard.go
+++ b/vcard.go
@@ -41,7 +41,6 @@ type VCard struct {
 	Logo            string `vcard:"LOGO"`
 	Mailer          string `vcard:"MAILER"`
 	Member          string `vcard:"MEMBER"`
-	Name            string `vcard:"NAME"` // No such field is defined in the RFC.
 	Note            string `vcard:"NOTE"`
 	Organization    string `vcard:"ORG"`
 	ProdID          string `vcard:"PRODID"`

--- a/vcard.go
+++ b/vcard.go
@@ -23,7 +23,7 @@ type VCard struct {
 	Email           string `vcard:"EMAIL"`
 	Version         string `vcard:"VERSION"`
 	Addr            string `vcard:"ADR"`
-	Anniversay      string `vcard:"ANNIVERSARY"`
+	Anniversary     string `vcard:"ANNIVERSARY"`
 	BirthDay        string `vcard:"BDAY"`
 	Nickname        string `vcard:"NICKNAME"`
 	Photo           string `vcard:"PHOTO"`
@@ -41,7 +41,7 @@ type VCard struct {
 	Logo            string `vcard:"LOGO"`
 	Mailer          string `vcard:"MAILER"`
 	Member          string `vcard:"MEMBER"`
-	Name            string `vcard:"NAME"`
+	Name            string `vcard:"NAME"` // No such field is defined in the RFC.
 	Note            string `vcard:"NOTE"`
 	Organization    string `vcard:"ORG"`
 	ProdID          string `vcard:"PRODID"`


### PR DESCRIPTION
Hi, I've been using the vcard-go project for some personal work, so thanks very much for making it available!

I have a number of changes/improvements to the code I'd like to propose, but although I'm a very experienced developer and Go programmer, I'm not experienced with the GitHub workflow, so I thought it would be good to start with a tiny change just to go through the process. Later, I'll follow with the more significant proposals.

This change consists of:
 1) a single typo fix (no impact on the rest of the code or tests, since the typo was in the field name, not the field tag that connects it to the record property, and the existing tests are somewhat cursory), plus
 2) a comment on the "Name" field, since the RFC doesn't actually specify/allow a name field.